### PR TITLE
Create dry-run.yml

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -29,6 +29,7 @@ jobs:
           DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           set -eo pipefail
-          export LIB_VERSION=${GITHUB_REF:11}
+          #export LIB_VERSION=${GITHUB_REF:11}
+          export LIB_VERSION=${GITHUB_REF##*/} # Gets the version from the github ref path
           echo "LIB_VERSION ${LIB_VERSION}"
           pod lib lint --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -22,5 +22,6 @@ jobs:
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF:11}
+          echo $LIB_VERSION
           pod lib lint --allow-warnings
           pod trunk push --allow-warnings

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Deploy to Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF:11}
@@ -26,4 +27,4 @@ jobs:
           echo $LIB_VERSION
           export LIB_VERSION=0.12.1
           pod lib lint --allow-warnings
-          pod trunk push --allow-warnings --verbose
+          pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -29,5 +29,5 @@ jobs:
           DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           set -eo pipefail
-          export LIB_VERSION=${GITHUB_REF##*/}
+          export LIB_VERSION=${GITHUB_REF:11}
           pod lib lint --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Deploy to Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-          #DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF:11}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   deploy-dry-run:
     runs-on: macos-latest
+    env:
+      ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
+      ARCHS: arm64 arm64e armv7 armv7s x86_64
     steps:
       - uses: actions/checkout@v2    
       - name: Install Cocoapods

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -31,5 +31,6 @@ jobs:
           echo "standard arches ${ARCHS_STANDARD}"
           echo "valid arches ${ARCHS_VALID}"
           export ARCHS_STANDARD=arm64 arm64e armv7 armv7s x86_64
+          export ARCHS_VALID=${ARCHS_STANDARD}
           pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Deploy to Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+          DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF##*/}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -31,6 +31,4 @@ jobs:
         run: |
           set -eo pipefail
           export LIB_VERSION=0.12.1
-          echo "standard arches ${ARCHS_STANDARD}"
-          echo "arches ${ARCHS}"
           pod lib lint --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     env:
       ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
-      ARCHS: ${ARCHS_STANDARD}
+      ARCHS: arm64 arm64e armv7 armv7s x86_64
     steps:
       - uses: actions/checkout@v2    
       - name: Install Cocoapods

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -30,4 +30,5 @@ jobs:
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF:11}
+          echo "LIB_VERSION ${LIB_VERSION}"
           pod lib lint --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -12,17 +12,15 @@ on:
 jobs:
   deploy-dry-run:
     runs-on: macos-latest
-      steps:
+    steps:
       - uses: actions/checkout@v2    
       - name: Install Cocoapods
         run: gem install cocoapods      
       - name: Deploy to Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-      run: |
-        set -eo pipefail
-        export LIB_VERSION=${GITHUB_REF:11}
-        pod lib lint --allow-warnings
-        pod trunk push --allow-warnings --verbose
-
-Show more debugging information
+        run: |
+          set -eo pipefail
+          export LIB_VERSION=${GITHUB_REF:11}
+          pod lib lint --allow-warnings
+          pod trunk push --allow-warnings

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -25,10 +25,12 @@ jobs:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
           ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
+          ARCHS: ${ARCHS_STANDARD}
           LIB_VERSION: ${GITHUB_REF##*/}
         run: |
           set -eo pipefail
           export LIB_VERSION=0.12.1
           echo "standard arches ${ARCHS_STANDARD}"
+          echo "arches ${ARCHS}"
           pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -24,5 +24,6 @@ jobs:
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF##*/}
           export LIB_VERSION=0.12.1
+          echo "standard arches ${STANDARD_ARCHES}"
           pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -12,9 +12,9 @@ on:
 jobs:
   deploy-dry-run:
     runs-on: macos-latest
-    #env:
-    #  ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
-    #  ARCHS: arm64 arm64e armv7 armv7s x86_64
+    env:
+      ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
+      ARCHS: arm64 arm64e armv7 armv7s x86_64
     steps:
       - uses: actions/checkout@v2    
       - name: Install Cocoapods

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -12,9 +12,6 @@ on:
 jobs:
   deploy-dry-run:
     runs-on: macos-latest
-    env:
-      ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
-      ARCHS: arm64 arm64e armv7 armv7s x86_64
     steps:
       - uses: actions/checkout@v2    
       - name: Install Cocoapods

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -4,7 +4,7 @@ on:
   # but only for the main branch
   push:
     branches:
-      - test/dry-run
+      - test/**
   pull_request:
     branches:
       - release/**

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -24,5 +24,6 @@ jobs:
           export LIB_VERSION=${GITHUB_REF:11}
           echo ${GITHUB_REF##*/}
           echo $LIB_VERSION
+          export LIB_VERSION=0.12.1
           pod lib lint --allow-warnings
-          pod trunk push --allow-warnings
+          pod trunk push --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,13 +1,7 @@
 name: deploy-cocoapod-dry-run
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
   push:
     branches:
-      - test/**
-  pull_request:
-    branches:
-      - release/**
       - test/**
 jobs:
   deploy-dry-run:

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF:11}
+          echo ${GITHUB_REF##*/}
           echo $LIB_VERSION
           pod lib lint --allow-warnings
           pod trunk push --allow-warnings

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -10,7 +10,19 @@ on:
       - release/**
       - test/**
 jobs:
-  test-run:
-    runs-on: ubuntu-latest
+  deploy-dry-run:
+  runs-on: macos-latest
     steps:
-      - run: echo "hello"
+    - uses: actions/checkout@v2    
+    - name: Install Cocoapods
+      run: gem install cocoapods      
+    - name: Deploy to Cocoapods
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      run: |
+        set -eo pipefail
+        export LIB_VERSION=${GITHUB_REF:11}
+        pod lib lint --allow-warnings
+        pod trunk push --allow-warnings --verbose
+
+Show more debugging information

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -28,6 +28,7 @@ jobs:
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF##*/}
           export LIB_VERSION=0.12.1
-          echo "standard arches ${STANDARD_ARCHS}"
+          echo "standard arches ${ARCHS_STANDARD}"
+          echo "valid arches ${ARCHS_VALID}"
           pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -29,7 +29,6 @@ jobs:
           DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           set -eo pipefail
-          #export LIB_VERSION=${GITHUB_REF:11}
-          export LIB_VERSION=${GITHUB_REF##*/} # Gets the version from the github ref path
+          export LIB_VERSION=${GITHUB_REF:11}
           echo "LIB_VERSION ${LIB_VERSION}"
           pod lib lint --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -24,13 +24,11 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+          ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
+          LIB_VERSION: ${GITHUB_REF##*/}
         run: |
           set -eo pipefail
-          export LIB_VERSION=${GITHUB_REF##*/}
           export LIB_VERSION=0.12.1
           echo "standard arches ${ARCHS_STANDARD}"
-          echo "valid arches ${ARCHS_VALID}"
-          export ARCHS_STANDARD=arm64 arm64e armv7 armv7s x86_64
-          export ARCHS_VALID=${ARCHS_STANDARD}
           pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -11,14 +11,14 @@ on:
       - test/**
 jobs:
   deploy-dry-run:
-  runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2    
-    - name: Install Cocoapods
-      run: gem install cocoapods      
-    - name: Deploy to Cocoapods
-      env:
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+    runs-on: macos-latest
+      steps:
+      - uses: actions/checkout@v2    
+      - name: Install Cocoapods
+        run: gem install cocoapods      
+      - name: Deploy to Cocoapods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
       run: |
         set -eo pipefail
         export LIB_VERSION=${GITHUB_REF:11}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Deploy to Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-          DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
+          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF:11}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,4 +1,4 @@
-name: publish-dry-run
+name: deploy-cocoapod-dry-run
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -30,7 +30,7 @@ jobs:
           LIB_VERSION: ${GITHUB_REF##*/}
         run: |
           set -eo pipefail
-          #export LIB_VERSION=0.12.1
-          #echo "standard arches ${ARCHS_STANDARD}"
-          #echo "arches ${ARCHS}"
+          export LIB_VERSION=0.12.1
+          echo "standard arches ${ARCHS_STANDARD}"
+          echo "arches ${ARCHS}"
           pod lib lint --allow-warnings --skip-tests --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
-          LIB_VERSION: ${GITHUB_REF##*/}
         run: |
           set -eo pipefail
+          export LIB_VERSION=${GITHUB_REF##*/}
           pod lib lint --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,0 +1,16 @@
+name: publish-dry-run
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - test/dry-run
+  pull_request:
+    branches:
+      - release/**
+      - test/**
+jobs:
+  test-run
+  runs-on: ubuntu-latest
+    steps:
+      - run: echo "hello"

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -30,5 +30,6 @@ jobs:
           export LIB_VERSION=0.12.1
           echo "standard arches ${ARCHS_STANDARD}"
           echo "valid arches ${ARCHS_VALID}"
+          export ARCHS_STANDARD=arm64 arm64e armv7 armv7s x86_64
           pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Deploy to Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+          #DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF:11}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -33,4 +33,4 @@ jobs:
           export LIB_VERSION=0.12.1
           echo "standard arches ${ARCHS_STANDARD}"
           echo "arches ${ARCHS}"
-          pod lib lint --allow-warnings --skip-tests --verbose
+          pod lib lint --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -30,5 +30,4 @@ jobs:
           LIB_VERSION: ${GITHUB_REF##*/}
         run: |
           set -eo pipefail
-          export LIB_VERSION=0.12.1
           pod lib lint --allow-warnings --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -10,7 +10,7 @@ on:
       - release/**
       - test/**
 jobs:
-  test-run
-  runs-on: ubuntu-latest
+  test-run:
+    runs-on: ubuntu-latest
     steps:
       - run: echo "hello"

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -12,9 +12,9 @@ on:
 jobs:
   deploy-dry-run:
     runs-on: macos-latest
-    env:
-      ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
-      ARCHS: arm64 arm64e armv7 armv7s x86_64
+    #env:
+    #  ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
+    #  ARCHS: arm64 arm64e armv7 armv7s x86_64
     steps:
       - uses: actions/checkout@v2    
       - name: Install Cocoapods
@@ -30,7 +30,7 @@ jobs:
           LIB_VERSION: ${GITHUB_REF##*/}
         run: |
           set -eo pipefail
-          export LIB_VERSION=0.12.1
-          echo "standard arches ${ARCHS_STANDARD}"
-          echo "arches ${ARCHS}"
+          #export LIB_VERSION=0.12.1
+          #echo "standard arches ${ARCHS_STANDARD}"
+          #echo "arches ${ARCHS}"
           pod lib lint --allow-warnings --skip-tests --verbose

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -28,6 +28,6 @@ jobs:
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF##*/}
           export LIB_VERSION=0.12.1
-          echo "standard arches ${STANDARD_ARCHES}"
+          echo "standard arches ${STANDARD_ARCHS}"
           pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   deploy-dry-run:
     runs-on: macos-latest
+    env:
+      ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
+      ARCHS: ${ARCHS_STANDARD}
     steps:
       - uses: actions/checkout@v2    
       - name: Install Cocoapods
@@ -24,8 +27,6 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
-          ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
-          ARCHS: ${ARCHS_STANDARD}
           LIB_VERSION: ${GITHUB_REF##*/}
         run: |
           set -eo pipefail

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -22,9 +22,7 @@ jobs:
           DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           set -eo pipefail
-          export LIB_VERSION=${GITHUB_REF:11}
-          echo ${GITHUB_REF##*/}
-          echo $LIB_VERSION
+          export LIB_VERSION=${GITHUB_REF##*/}
           export LIB_VERSION=0.12.1
-          pod lib lint --allow-warnings
+          pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -16,10 +16,14 @@ jobs:
       - uses: actions/checkout@v2    
       - name: Install Cocoapods
         run: gem install cocoapods      
+      
+      - uses: maxim-lobanov/setup-xcode@v1
+        with: 
+          xcode-version: 11.7
       - name: Deploy to Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-          DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
+          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF##*/}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -33,5 +33,5 @@ jobs:
           export LIB_VERSION=0.12.1
           echo "standard arches ${ARCHS_STANDARD}"
           echo "arches ${ARCHS}"
-          pod lib lint --allow-warnings --verbose
+          pod lib lint --allow-warnings --skip-tests --verbose
           pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -34,4 +34,3 @@ jobs:
           echo "standard arches ${ARCHS_STANDARD}"
           echo "arches ${ARCHS}"
           pod lib lint --allow-warnings --skip-tests --verbose
-          pod trunk push --allow-warnings ----local-only --verbose 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: deploy-cocoapod-dry-run
+name: publish
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,5 @@ jobs:
         run: |
           set -eo pipefail
           export LIB_VERSION=${GITHUB_REF:11}
-          echo "LIB_VERSION ${LIB_VERSION}"
           pod lib lint --allow-warnings --verbose
           pod trunk push --allow-warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,35 @@
-name: publish pod
+name: deploy-cocoapod-dry-run
 on:
-  release:
-    types: 
-      - released
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - test/dry-run
+  pull_request:
+    branches:
+      - release/**
+      - test/**
 jobs:
-  deploy:
+  deploy-dry-run:
     runs-on: macos-latest
+    env:
+      ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64
+      ARCHS: arm64 arm64e armv7 armv7s x86_64
     steps:
-    - uses: actions/checkout@v2    
-    - name: Install Cocoapods
-      run: gem install cocoapods      
-    - name: Deploy to Cocoapods
-      env:
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-      run: |
-        set -eo pipefail
-        export LIB_VERSION=${GITHUB_REF:11}
-        pod lib lint --allow-warnings
-        pod trunk push --allow-warnings
+      - uses: actions/checkout@v2    
+      - name: Install Cocoapods
+        run: gem install cocoapods      
+      
+      - uses: maxim-lobanov/setup-xcode@v1
+        with: 
+          xcode-version: 11.7
+      - name: Deploy to Cocoapods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+        run: |
+          set -eo pipefail
+          export LIB_VERSION=${GITHUB_REF:11}
+          echo "LIB_VERSION ${LIB_VERSION}"
+          pod lib lint --allow-warnings --verbose
+          pod trunk push --allow-warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
     types: 
       - released
 jobs:
-  deploy-dry-run:
+  deploy:
     runs-on: macos-latest
     env:
       ARCHS_STANDARD: arm64 arm64e armv7 armv7s x86_64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,8 @@
-name: publish
+name: publish pod
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
-  push:
-    branches:
-      - test/dry-run
-  pull_request:
-    branches:
-      - release/**
-      - test/**
+  release:
+    types: 
+      - released
 jobs:
   deploy-dry-run:
     runs-on: macos-latest


### PR DESCRIPTION
This PR modifies the `publish.yml` workflow to address a couple of issues seen during the `pod lint` step.

We now specify the use of Xcode 11.7 (instead of Xcode 11) which is is no longer supported on the github OS X VMs.

To resolve a rather opaque issue about which architectures is targeted in both `pod lint` step and the user build step, one solution has been to add `ARCHS=$ARCHS_STANDARD` to the SDK's podspec. It seems that we also need to specify the value of $ARCHS_STANDARD in the workflow.

In future it looks like we will able to completely remove the configuration of ARCHS from the podspec and thereby allow each build to decide which architectures to target.

In the PR there is also a `dry-run.yml` which can be considered as a "Debug" version of `publish.yml`. Its purpose is to allow troubleshooting of the `publish.yml` without actually performing the last step of `pod publish`. It will trigger on pushes to `test` e.g. `test/0.13.0` (NOTE the branch name should be in valid semver format otherwise cocoapods will throw and error during `pod lint`)